### PR TITLE
Adding an option to visit a page without erroring if it redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ pry> simple_site
 ### Example: Page Redirection via Pry
 
 ```bash
-pry> redirect_page.visit # => should redirect to home page
+pry> redirect_page.visit(false) # => should redirect to home page; "false" tells it not to validate that the page landed on is the page requested
 pry> redirect_page.displayed? # => false
 pry> home_page.displayed? # => true
 ```

--- a/lib/gamera/page.rb
+++ b/lib/gamera/page.rb
@@ -141,11 +141,13 @@ module Gamera
 
     # Open the page url in the browser specified in your Capybara configuration
     #
-    # @raise [WrongPageVisited] if the site redirects to URL that doesn't match
-    #   the url_matcher regex
-    def visit
+    # @param fail_on_redirect [Boolean] Whether to fail if the site redirects to a page that does not match the url_matcher regex
+    # @raise [WrongPageVisited] if the site redirects to URL that doesn't match the url_matcher regex and fail_on_redirect is true
+    def visit(fail_on_redirect = true)
       super(url)
-      fail WrongPageVisited, "Expected URL '#{url}', got '#{page.current_url}'" unless displayed?
+      if fail_on_redirect
+        fail WrongPageVisited, "Expected URL '#{url}', got '#{page.current_url}'" unless displayed?
+      end
     end
 
     # Check to see if we eventually land on the right page

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -51,6 +51,11 @@ describe 'Page' do
     expect(home_page).to be_displayed
   end
 
+  it 'ignores a redirect if told to' do
+    redirect_page = RedirectPage.new
+    expect { redirect_page.visit(false) }.not_to raise_error
+  end
+
   it 'refreshes until a condition is met and then stops refreshing' do
     hit_counter_page.visit
 


### PR DESCRIPTION
There was no way to visit a page that redirects. We should be able to do this. There was also an example in the README that would throw an error as written because of this.
