### PR TITLE
Allowing checkboxes on forms

### DIFF
--- a/lib/gamera/page_sections/form.rb
+++ b/lib/gamera/page_sections/form.rb
@@ -93,7 +93,7 @@ module Gamera
       def fill_in_form(fields)
         fields.each do |field, value|
           f = send("#{field}_field")
-          f.set(value.to_s) || Array(value).each { |val| f.select(val) }
+          f.set(value) || Array(value).each { |val| f.select(val) }
         end
       end
 

--- a/spec/resources/simple_form/simple_form.rb
+++ b/spec/resources/simple_form/simple_form.rb
@@ -34,8 +34,9 @@ class SimpleForm < Sinatra::Base
 
   post '/form' do
     "You entered '#{params[:text]}', " \
-    "you selected '#{params[:select]}' from the single select field " \
-    "and you selected '#{params[:multi_select].join(',')}' from the multiple select field"
+    "you selected '#{params[:select]}' from the single select field, " \
+    "you selected '#{params[:multi_select].join(',')}' from the multiple select field, " \
+    "and you #{params[:checkbox] ? 'checked' : 'did not check'} the checkbox."
   end
 
   run! if app_file == $PROGRAM_NAME

--- a/spec/resources/simple_form/simple_form_page.rb
+++ b/spec/resources/simple_form/simple_form_page.rb
@@ -35,7 +35,7 @@ class SimpleFormPage < Gamera::Page
   def initialize
     super('/', %r{\/})
 
-    fields = %w(Text Selection MultipleSelection)
+    fields = %w(Text Selection MultipleSelection Checkbox)
 
     @form = Gamera::PageSections::Form.new(fields)
 

--- a/spec/resources/simple_form/views/form.erb
+++ b/spec/resources/simple_form/views/form.erb
@@ -23,6 +23,11 @@
   </p>
 
   <p>
+    <label for="checkbox">Checkbox</label>
+    <input type="checkbox" id="checkbox" name="checkbox">
+  </p>
+
+  <p>
     <input type="submit" name="submit" value="Submit">
   </p>
 </form>

--- a/spec/unit/page_sections/form_spec.rb
+++ b/spec/unit/page_sections/form_spec.rb
@@ -41,6 +41,15 @@ describe 'SimpleFormPage' do
     form_page.fill_in_form(text: 'Entered Text', selection: 'C', multipleselection: %w(A C))
     form_page.submit
 
-    expect(form_page.text).to eq("You entered 'Entered Text', you selected 'C' from the single select field and you selected 'A,C' from the multiple select field")
+    expect(form_page.text).to eq("You entered 'Entered Text', you selected 'C' from the single select field, you selected 'A,C' from the multiple select field, and you did not check the checkbox.")
+  end
+
+  it 'fills in a checkbox properly' do
+    form_page = SimpleFormPage.new
+
+    form_page.visit
+    form_page.fill_in_form(multipleselection: ['A'], checkbox: true)
+    form_page.submit
+    expect(form_page.text).to include("you checked the checkbox.")
   end
 end


### PR DESCRIPTION
As a side effect, this now doesn't allow symbols to be passed in as field values, but I think those should be strings anyway.
