### PR TITLE
Relax Ruby requirements to allow gem with newer versions of Ruby

### DIFF
--- a/gamera.gemspec
+++ b/gamera.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'PageObject pattern implementation based on Capybara'
   s.description = 'Provides a framework which lets you wrap any web page with a Ruby API.'
 
-  s.required_ruby_version = '~> 2.1', '>= 2.1.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.files            = `git ls-files -- lib/*`.split("\n")
 


### PR DESCRIPTION
* Ruby 2.1.X is no longer supported (https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/)

* Allow any Ruby newer than 2.1.0